### PR TITLE
[2024-12-27] jeoeo #151

### DIFF
--- a/Baekjoon/문제풀이/오큰수/jeoeo.java
+++ b/Baekjoon/문제풀이/오큰수/jeoeo.java
@@ -1,0 +1,45 @@
+package coding_study.Baekjoon.문제풀이.오큰수;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.Stack;
+import java.util.StringTokenizer;
+
+public class jeoeo {
+  public static void main(String[] args) throws IOException {
+    BufferedReader br = new BufferedReader((new InputStreamReader(System.in)));
+    BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+    int N = Integer.parseInt(br.readLine());
+
+    int[] A = new int[N];
+    int[] result = new int[N];
+    StringTokenizer st = new StringTokenizer(br.readLine());
+
+    for (int i = 0; i < N; i++) {
+      A[i] = Integer.parseInt(st.nextToken());
+    }
+
+    Stack<Integer> stack = new Stack<>();
+
+    for (int i = 0; i < N; i++) {
+      while (!stack.isEmpty() && A[stack.peek()] < A[i]) {
+        result[stack.pop()] = A[i];
+      }
+      stack.push(i);
+    }
+
+    while (!stack.isEmpty()) {
+      result[stack.pop()] = -1;
+    }
+    for (int i = 0; i < N; i++) {
+      bw.write(result[i]+" ");
+    }
+    
+    bw.flush(); 
+    bw.close(); 
+  }
+}


### PR DESCRIPTION
### PR Summary
풀이 시작 : 2024-12-27

#### 제한사항
각 수의 오큰수를 공백으로 구분해 한 줄로 출력해야 함
오큰수가 없으면 -1로 출력

#### 풀이
현재 원소 A[i]와 스택 최상단 인덱스에 해당하는 값 A[stack.peek()]를 비교
- A[stack.peek()] < A[i] : 스택에서 인덱스를 꺼내 해당 위치의 오큰수를 A[i]로 설정
- A[stack.peek()] >= A[i] : 현재 원소를 처리하기 위해 스택에 현재 인덱스를 추가
배열 끝까지 순회 후에도 스택에 남아있는 인덱스는 오큰수가 없는 원소를 의미

풀이 완료 : 2024-12-27