### PR TITLE
[2025-02-09] yuri #440

### DIFF
--- a/Baekjoon/문제풀이/2xn 타일링/yuri.java
+++ b/Baekjoon/문제풀이/2xn 타일링/yuri.java
@@ -1,0 +1,27 @@
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        int input = sc.nextInt();
+        
+        // dp 배열을 위해 입력 값보다 2 큰 크기를 잡습니다(아마추어스럽게).
+        int[] arr = new int[input + 2];
+        
+        // 기저값 설정
+        arr[1] = 1;  // n=1
+        if (input > 1) {
+            arr[2] = 2;  // n=2
+        }
+        
+        // 점화식: dp[n] = dp[n-1] + dp[n-2]
+        for (int i = 3; i <= input; i++) {
+            arr[i] = arr[i-1] + arr[i-2];
+            arr[i] = arr[i] % 10007;  // 매번 나머지 연산
+        }
+        
+        // 결과 출력
+        System.out.println(arr[input] % 10007);
+        sc.close();
+    }
+}


### PR DESCRIPTION
PR Summary
풀이 시작 : 2025-02-05

제한사항
- n은 1 이상 1000 이하의 정수
- 2×n 직사각형을 1×2, 2×1 타일로 채우는 방법의 수
- 결과를 10,007로 나눈 나머지를 출력

풀이
n 길이에 해당하는 모든 경우의 수
- 크기가 (n+2)인 배열 arr을 만들어 DP를 저장
- arr[1] = 1, arr[2] = 2 로 초기값을 설정
- 이후 i=3부터 n까지 arr[i] = arr[i-1] + arr[i-2]
- 각 단계에서 10,007로 나눈 나머지를 arr[i]에 저장하여 숫자가 너무 커지지 않게 한다.
- 마지막으로 arr[n]을 출력하면 n까지의 모든 타일링 방법 수

풀이 완료 : 2025-02-05
