### PR TITLE
[2025-02-09] yuri #440

### DIFF
--- a/Baekjoon/문제풀이/2xn 타일링2/yuri.java
+++ b/Baekjoon/문제풀이/2xn 타일링2/yuri.java
@@ -1,0 +1,23 @@
+import java.util.Scanner;
+
+public class Main {
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        int n = sc.nextInt();
+        
+        int[] arr = new int[n + 2];
+        
+        arr[1] = 1; // n=1
+        if (n > 1) {
+            arr[2] = 3; // n=2
+        }
+        
+        for (int i = 3; i <= n; i++) {
+            arr[i] = (arr[i-1] + 2 * arr[i-2]) % 10007;
+        }
+        
+        System.out.println(arr[n] % 10007);
+        
+        sc.close();
+    }
+}


### PR DESCRIPTION
PR Summary
풀이 시작 : 2025-02-09

제한사항
- n은 1 이상 1000 이하의 정수
- 2×n 직사각형을 1×2, 2×1, 2×2 타일로 채우는 방법의 수
- 결과를 10,007로 나눈 나머지를 출력

풀이
- 크기가 (n+2)인 배열 arr을 사용해서 DP를 저장
- arr[1] = 1, arr[2] = 3 으로 초기값을 설정 (2×2 블록을 고려해야 하므로 이전 문제와 다름)
- i=3부터 n까지 arr[i] = arr[i-1] + 2×arr[i-2] 로 점화식 (2×2를 놓는 경우 때문에 곱하기 2)
- 10,007로 나눈 나머지를 arr[i]에 저장 (오버플로우 방지)

풀이 완료 : 2025-02-09

