### PR TITLE
[2025-02-16] hyunjune #489

### DIFF
--- a/Baekjoon/문제풀이/이친수/hyunjune.java
+++ b/Baekjoon/문제풀이/이친수/hyunjune.java
@@ -1,0 +1,26 @@
+package Baekjoon.문제풀이.이친수;
+
+import java.util.Scanner;
+
+public class hyunjune {
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        int n = sc.nextInt();
+        sc.close();
+
+        if (n == 1) {
+            System.out.println(1);
+            return;
+        }
+
+        long[] dp = new long[n + 1];
+        dp[1] = 1;
+        dp[2] = 1;
+
+        for (int i = 3; i <= n; i++) {
+            dp[i] = dp[i - 1] + dp[i - 2];
+        }
+
+        System.out.println(dp[n]);
+    }
+}


### PR DESCRIPTION
### PR Summary
풀이 시작 : 2025-02-15

#### 제한사항

#### 풀이
1. 해당 문제의 경우 피보나치 수열과 같은 구조이다. 따라서 수열의 첫번째와 두번째만 값을 정해주면 된다.
2. 피보나치의 수열처럼 증가하는 이유는 2번째 값부터 발생하는 끝자리 0의 갯수가 하나인데, 끝자리가 0인 경우만 다음에서 두개로 늘어나고 끝자리가 1이면 0 하나만 추가하는 방법 밖에 없다.
3. 따라서 기존에 있는 0의 갯수가 이전 수열의 갯수만큼 증가하게 된다. 이로서 피보나치 수열과의 연관성이 입증된다.

풀이 완료 : 2025-02-15